### PR TITLE
Uploading cpan cookbook with berkshelf fails without explicit cookbook name in metadata

### DIFF
--- a/cpan/metadata.rb
+++ b/cpan/metadata.rb
@@ -1,3 +1,4 @@
+name             "cpan"
 maintainer       "Alexey Melezhik"
 maintainer_email "melezhik@gmail.com"
 license          "All rights reserved"


### PR DESCRIPTION
Small change, but fixes an integration issue with berkshelf.  I'm happy to fix this issue in all your cookbooks if you prefer.
