### PR TITLE
Change cpanm target to just "Pinto"

### DIFF
--- a/pinto/recipes/application.rb
+++ b/pinto/recipes/application.rb
@@ -6,5 +6,5 @@ node.pinto.bootstrap.packages.each do |p|
     package p
 end
 
-execute 'cpanm App::Pinto --sudo'
+execute 'cpanm Pinto --sudo'
 


### PR DESCRIPTION
The official "main module" is Pinto, so that should probably be what cpanm installs.
