### PR TITLE
added perl-CPAN to package list

### DIFF
--- a/cpan/attributes/default.rb
+++ b/cpan/attributes/default.rb
@@ -3,6 +3,7 @@ default.cpan_client.bootstrap.packages = ['curl']
 case platform
 when 'centos'
     default.cpan_client.bootstrap.packages << 'perl-devel'
+    default.cpan_client.bootstrap.packages << 'perl-CPAN'
 end
 
 default.cpan_client.bootstrap.cpan_packages = ['Time::HiRes', 'CPAN', 'local::lib', 'App::pmuninstall']


### PR DESCRIPTION
I was having issues using the bootstrap script without installing this package using centos and amazon distributions.
