### PR TITLE
Fix the order of parameters to Iconv#initialize

### DIFF
--- a/cpan/providers/client.rb
+++ b/cpan/providers/client.rb
@@ -87,7 +87,7 @@ def sanity_string file_contents
     if String.method_defined?(:encode)
       file_contents.encode!('UTF-8', 'UTF-8', :invalid => :replace)
     else
-      ic = Iconv.new('UTF-8', 'UTF-8//IGNORE')
+      ic = Iconv.new('UTF-8//IGNORE', 'UTF-8')
       file_contents = ic.iconv(file_contents)
     end
 end


### PR DESCRIPTION
Some modules print messages with non-UTF-8 message especially when running test.
It may cause errors with Chef on Ruby 1.8 / Iconv.
