### PR TITLE
add cookbook name

### DIFF
--- a/nginx-fastcgi/metadata.rb
+++ b/nginx-fastcgi/metadata.rb
@@ -1,3 +1,4 @@
+name             "nginx-fastcgi"
 maintainer       "Alexey Melezhik"
 maintainer_email "melezhik@gmail.com"
 license          "All rights reserved"


### PR DESCRIPTION
This adds the nginx-fastcgi cookbook name to the metadata.rb file of the nginx-fastcgi cookbook, which is needed for the latest versions of Chef.