### PR TITLE
Fix for issue #29 - "undefined method cpan_client" with Chef 13

### DIFF
--- a/cpan/attributes/default.rb
+++ b/cpan/attributes/default.rb
@@ -1,15 +1,13 @@
-default.cpan_client.bootstrap.packages = ['curl']
+default['cpan_client']['bootstrap']['packages'] = ['curl']
 
-case platform
+case node['platform']
 when 'centos'
-    default.cpan_client.bootstrap.packages << 'perl-devel'
-    default.cpan_client.bootstrap.packages << 'perl-CPAN'
+    default['cpan_client']['bootstrap']['packages'] << 'perl-devel'
+    default['cpan_client']['bootstrap']['packages'] << 'perl-CPAN'
 end
 
-default.cpan_client.bootstrap.cpan_packages = ['Time::HiRes', 'CPAN::Meta', 'CPAN', 'local::lib', 'App::pmuninstall']
+default['cpan_client']['bootstrap’][‘cpan_packages'] = ['Time::HiRes', 'CPAN::Meta', 'CPAN', 'local::lib', 'App::pmuninstall']
 
-default.cpan_client.default_inc = []
+default['cpan_client']['default_inc'] = []
 
-default.cpan_client.bootstrap.keep_uptodate = true
-
-
+default['cpan_client']['bootstrap']['keep_uptodate'] = true


### PR DESCRIPTION
See: https://github.com/melezhik/cookbooks/issues/29

Fixed cpan/attributes/default.rb so that Chef 13 does not throw this exception: 'undefined method cpan_client'.
